### PR TITLE
fix(version): use build time first

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -19,13 +19,14 @@ const LOCAL_RPC_URL: &str = "http://127.0.0.1:8545";
 pub const DAPP_JSON: &str = "./out/dapp.sol.json";
 
 /// The version message for the current program, like
+/// |--CARGO---| |-----BUILD_TIME------| |---GIT_SHA_SHORT--|
 /// `forge 0.1.0 (f01b232bc 2022-01-22T23:28:39.493201+00:00)`
 pub(crate) const VERSION_MESSAGE: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     " (",
-    env!("VERGEN_GIT_SHA_SHORT"),
-    " ",
     env!("VERGEN_BUILD_TIMESTAMP"),
+    " ",
+    env!("VERGEN_GIT_SHA_SHORT"),
     ")"
 );
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Arrange versioning by build time instead of git sha. git sha is not semantically understandable and provides no benefit to sorting versions of foundry builds. using build time at least provides a chronological sort of versions 

## Solution

enable chronological sort by using build time first
